### PR TITLE
Add (de)serialization using serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/Stebalien/snowflake"
 homepage = "https://github.com/Stebalien/snowflake"
 documentation = "https://stebalien.github.io/snowflake/snowflake"
 
+[dependencies]
+serde = "*"
+serde_derive = "*"
+
 [dev-dependencies]
 time = "0.1"
 uuid = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 //! This crate currently includes guaranteed process unique IDs but may include new ID types in the
 //! future.
 
+#[macro_use] extern crate serde_derive;
+
 mod process_unique_id;
 
 pub use process_unique_id::ProcessUniqueId;

--- a/src/process_unique_id.rs
+++ b/src/process_unique_id.rs
@@ -52,7 +52,7 @@ thread_local! {
 /// IDs in a reasonable amount of time is to run a 32bit system, spawn 2^32 threads, and claim one
 /// ID on each thread. You might be able to do this on a 64bit system but it would take a while...
 /// TL; DR: Don't create unique IDs from over 4 billion different threads on a 32bit system.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize, Serialize)]
 pub struct ProcessUniqueId {
     prefix: usize,
     offset: u64,


### PR DESCRIPTION
Thank you for creating this crate. I have found it extremely useful in a handful of applications and projects I have been working on. I would like to contribute by adding the ability to serialize and deserialize the Process Unique Identifier (PUID). The serde (https://serde.rs/) crate is used to implement serialization and deserialization. The `Deserialize` and `Serialize` traits are derived using the macros from the serde_derive crate.

I had a need in an application to transmit the Process Unique Id (PUID) over a TCP stream. I was converting the ProcessUniqueId to a string using the Display trait, but I thought it would be more elegant and versatile to implement serialization and deserialization with the serde crate. I think it might be possible to create duplicate PUIDs with deserialization, so this might need to be added with caution. 

I looked at the contribution section of the README and I am okay with the licensing. Please let me know if there is anything else I should do to merge these changes. Thank you.